### PR TITLE
docs: fix typo in index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ pretty early state, though we hope you will find it useful.
     **yapCAD** was created to solve some fairly specific problems in
     procedural CAD and `parametric design`_ , and at present is most
     developed for generating 2D drawings in the `AutoCad DXF`_ format.
-    If you don't know what procedural CAD or paramaterized design
+    If you don't know what procedural CAD or parameterized design
     might be useful for, this may not be the tool for you.
 
     On the other hand, if you are tired of manually editing your CAD


### PR DESCRIPTION
## Summary
- fix parameterized spelling in index page

## Testing
- `make -C docs html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ad5e9a21208326bc85dfb0514249bc