### PR TITLE
Use geom.scale3 for inverse translation

### DIFF
--- a/src/yapcad/xform.py
+++ b/src/yapcad/xform.py
@@ -232,7 +232,7 @@ def Rotation(axis,angle,inverse=False):
 
 def Translation(delta,inverse=False):
     if inverse:
-        delta = mul(delta,-1.0)
+        delta = geom.scale3(delta, -1.0)
     dx = delta[0]
     dy = delta[1]
     dz = delta[2]


### PR DESCRIPTION
## Summary
- Use `geom.scale3` to negate translation vectors instead of custom `mul`

## Testing
- `pytest -q`
- `python - <<'PY'
from yapcad.xform import Translation
m = Translation((1,2,3), inverse=True)
print(m.m)
PY`


------
https://chatgpt.com/codex/tasks/task_b_68ad5f44f75083269263bef903e2714a