### PR TITLE
Clarify Matrix.mul error handling

### DIFF
--- a/src/yapcad/xform.py
+++ b/src/yapcad/xform.py
@@ -165,11 +165,17 @@ class Matrix:
             self.m[j] = x
         
 
-    # matrix multiply.  If x is a matrix, compute MX.  If X is a
+    # matrix multiply.  If x is a matrix, compute MX.  If x is a
     # vector, compute Mx. If x is a scalar, compute xM. If x isn't any
-    # of these, return False.  Respects transpose flag.
-    
+    # of these, a ValueError is raised.  Respects transpose flag.
+
     def mul(self,x):
+        """Return the product of this matrix and ``x``.
+
+        ``x`` may be another :class:`Matrix`, a 4D vector, or a scalar. In
+        each case the appropriate matrix multiplication is performed. If
+        ``x`` is none of these types, a :class:`ValueError` is raised.
+        """
         if isinstance(x,Matrix):
             result = Matrix()
             for i in range(4):


### PR DESCRIPTION
## Summary
- Document that `Matrix.mul` raises `ValueError` for unsupported operand types
- Add docstring for `Matrix.mul` describing valid operands and error behavior

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ad6143db3483269cddd2b3f9c8c95e