### PR TITLE
Require Python 3.10 and expand tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,18 @@ authors = [
 ]
 description = "yet another procedural CAD and computational geometry system"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
-	      "ezdxf",
-	      "pyglet < 2",
-	      "mpmath"
-	      ]
+              "ezdxf",
+              "pyglet",
+              "mpmath"
+              ]
 
 [project.optional-dependencies]
 tests = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@
 # scipy==1.0
 #
 ezdxf
-pyglet<2
+pyglet
 mpmath

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,11 @@ package_dir =
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = ezdxf; pyglet<2; mpmath
+install_requires = ezdxf; pyglet; mpmath
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-# python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+python_requires = >=3.10
 
 [options.packages.find]
 where = src

--- a/tests/test_poly.py
+++ b/tests/test_poly.py
@@ -1,0 +1,15 @@
+from yapcad.poly import Polyline, Polygon
+from yapcad.geom import point, vclose
+
+
+def test_polyline_center_and_sample():
+    pts = [point(0,0), point(2,0), point(2,2)]
+    pl = Polyline(pts)
+    assert vclose(pl.getCenter(), point(4/3, 2/3))
+    assert vclose(pl.sample(0.75), point(2, 1))
+
+
+def test_polygon_wrap_sampling():
+    square = Polygon([point(0,0), point(1,0), point(1,1), point(0,1)])
+    assert vclose(square.getCenter(), point(0.5, 0.5))
+    assert vclose(square.sample(1.25), point(1, 0))


### PR DESCRIPTION
## Summary
- require Python 3.10 and allow latest pyglet releases
- document version requirement in setup configuration
- add unit tests for Polyline and Polygon sampling

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ad64ded094832698a008851b255415