### PR TITLE
Require Python 3.10, pin pyglet 1.x, guard OpenGL examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
+venv/
+v_*/
+
+#cached python version for pyenv
+.python-version
 
 # generated DXF files in examples
 examples/*.dxf

--- a/examples/boxcut/boxcut.py
+++ b/examples/boxcut/boxcut.py
@@ -561,8 +561,17 @@ if __name__ == "__main__":
     dd.display()
 
     if ogl:
-        from yapcad.pyglet_drawable import *
-        dd2 = pygletDraw()
+        try:
+            from yapcad.pyglet_drawable import *
+            dd2 = pygletDraw()
+        except RuntimeError as err:
+            print("\nSkipping 3D visualization: {}".format(err))
+            ogl = False
+        except Exception as err:
+            print("\nSkipping 3D visualization due to unexpected error: {}".format(err))
+            ogl = False
+
+    if ogl:
         # magnification factor for text
         dd2.magnify=1.5
         # compute the camera distance assuming a 60 degree (pi/6) FOV
@@ -571,13 +580,9 @@ if __name__ == "__main__":
         dist = ((maxd/2) / math.sin(pi/6))*math.cos(pi/6)
         dd2.cameradist = dist-box_height*2
 
-        
         twoDDraw(polys,dd2,-box_height*2)
 
         oglGeom = makeOglGeom()
-        #print("oglGeom: ",oglGeom)
-
-        #oglGeom = translate(oglGeom,point(0,0,box_height))
 
         dd2.layer='PATHS'
         for i in range(len(oglGeom)):
@@ -587,8 +592,6 @@ if __name__ == "__main__":
                 dd2.linecolor = 'aqua'
             else:
                 dd2.linecolor = 'fuchsia'
-                
             dd2.draw(oglGeom[i])
         dd2.display()
     print("done")
-

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -7,7 +7,11 @@ from yapcad.geom import *
 
 #set up openGL rendering
 def setupGL():
-    dGl =pygletDraw()
+    try:
+        dGl = pygletDraw()
+    except RuntimeError as err:
+        print("\nSkipping OpenGL rendering: {}".format(err))
+        return None
     dGl.magnify = 1.0
     dGl.linecolor = 'white'
     dGl.cameradist = 25
@@ -107,15 +111,18 @@ if __name__ == "__main__":
     ## add a drawing legend in the OpenGL rendering, setting the
     ## color eplicitly to yellow
     
-    dGl.linecolor = 'yellow'
-    legend(dGl)
+    if dGl:
+        dGl.linecolor = 'yellow'
+        legend(dGl)
     
     ## draw the geometry in OpenGL
-    drawGlist(geomlist,dGl)
+    if dGl:
+        drawGlist(geomlist,dGl)
 
     ## write out the DXF file as example1-out.dxf
     d.display()
 
     ## create the interactive OpenGL rendering -- do this last
-    dGl.display()
+    if dGl:
+        dGl.display()
     

--- a/examples/example10.py
+++ b/examples/example10.py
@@ -203,17 +203,30 @@ if __name__ == "__main__":
             quit()
     if len(sys.argv) > 2 and renderOgl==False:
         filename = sys.argv[2]+".dxf"
-    dd = []
+    requestedOgl = renderOgl
+    dd = None
     if renderOgl:
         print("OpenGL rendering selected")
-        from yapcad.pyglet_drawable import *
-        dd=pygletDraw()
-    else:
-        print("DXF rendering selected")
+        try:
+            from yapcad.pyglet_drawable import *
+            dd=pygletDraw()
+        except RuntimeError as err:
+            print("\nSkipping OpenGL rendering: {}".format(err))
+            renderOgl = False
+        except Exception as err:
+            print("\nSkipping OpenGL rendering due to unexpected error: {}".format(err))
+            renderOgl = False
+
+    if not renderOgl or dd is None:
+        if requestedOgl and dd is None:
+            print("Falling back to DXF rendering")
+        else:
+            print("DXF rendering selected")
         from yapcad.ezdxf_drawable import *
         #set up DXF rendering
         dd=ezdxfDraw()
         dd.filename = filename
+        renderOgl = False
     print("rendering...")
     testAndDraw(dd)
     print("done")

--- a/examples/example11.py
+++ b/examples/example11.py
@@ -106,17 +106,30 @@ if __name__ == "__main__":
             quit()
     if len(sys.argv) > 2 and renderOgl==False:
         filename = sys.argv[2]+".dxf"
-    dd = []
+    requestedOgl = renderOgl
+    dd = None
     if renderOgl:
         print("OpenGL rendering selected")
-        from yapcad.pyglet_drawable import *
-        dd=pygletDraw()
-    else:
-        print("DXF rendering selected")
+        try:
+            from yapcad.pyglet_drawable import *
+            dd=pygletDraw()
+        except RuntimeError as err:
+            print("\nSkipping OpenGL rendering: {}".format(err))
+            renderOgl = False
+        except Exception as err:
+            print("\nSkipping OpenGL rendering due to unexpected error: {}".format(err))
+            renderOgl = False
+
+    if not renderOgl or dd is None:
+        if requestedOgl and dd is None:
+            print("Falling back to DXF rendering")
+        else:
+            print("DXF rendering selected")
         from yapcad.ezdxf_drawable import *
         #set up DXF rendering
         dd=ezdxfDraw()
         dd.filename = filename
+        renderOgl = False
     print("rendering...")
     testAndDraw(dd)
     print("done")

--- a/examples/example12.py
+++ b/examples/example12.py
@@ -44,6 +44,7 @@ def geometry():
     jigsaw=makeJigsawPiece(poly=True)
     bigc= makeCircle(point(0,0,0),20)
     nb = Boolean('union',[logopoly,bigc])
+    nb = nb.scale(0.8,poly=True)
     nb = nb.translate(point(0,-50),poly=True)
     docGeomList.append(nb.geom())
 
@@ -74,6 +75,8 @@ def testAndDraw(dd):
     else:
         dd.linecolor = 'aqua'
     dd.draw(geom2)
+    dd.linecolor = 'red'
+    dd.draw(translate(geom,point(0,0,5)))
 
     if not renderOgl:
         dd.layer = 'DOCUMENTATION'
@@ -114,20 +117,32 @@ if __name__ == "__main__":
             quit()
     if len(sys.argv) > 2 and renderOgl==False:
         filename = sys.argv[2]+".dxf"
-    dd = []
+    requestedOgl = renderOgl
+    dd = None
     if renderOgl:
         print("OpenGL rendering selected")
-        from yapcad.pyglet_drawable import *
-        dd=pygletDraw()
-        dd.cameradist=170.0
-        
-    else:
-        print("DXF rendering selected")
+        try:
+            from yapcad.pyglet_drawable import *
+            dd=pygletDraw()
+            dd.cameradist=170.0
+        except RuntimeError as err:
+            print("\nSkipping OpenGL rendering: {}".format(err))
+            renderOgl = False
+        except Exception as err:
+            print("\nSkipping OpenGL rendering due to unexpected error: {}".format(err))
+            renderOgl = False
+
+    if not renderOgl or dd is None:
+        if requestedOgl and dd is None:
+            print("Falling back to DXF rendering")
+        else:
+            print("DXF rendering selected")
         from yapcad.ezdxf_drawable import *
         #set up DXF rendering
         dd=ezdxfDraw()
         dd.filename = filename
         drawLegend(dd)
+        renderOgl = False
     print("rendering...")
     
     testAndDraw(dd)

--- a/examples/example8-gl.py
+++ b/examples/example8-gl.py
@@ -1,5 +1,6 @@
 ## yapCAD poly() intersecton and drawing examples
 
+import sys
 from yapcad.geom import *
 from yapcad.poly import *
 import random
@@ -14,8 +15,15 @@ if __name__ == "__main__":
  making and then mirroring random "flowers."  Renders output interactively with OpenGL.
     """)
 
-    from yapcad.pyglet_drawable import *
-    dd=pygletDraw()
+    try:
+        from yapcad.pyglet_drawable import *
+        dd=pygletDraw()
+    except RuntimeError as err:
+        print("\nSkipping OpenGL rendering: {}".format(err))
+        sys.exit(0)
+    except Exception as err:
+        print("\nSkipping OpenGL rendering due to unexpected error: {}".format(err))
+        sys.exit(1)
     dd.cameradist=150.0
     glist = mirrorArray()
 

--- a/examples/example9.py
+++ b/examples/example9.py
@@ -117,7 +117,16 @@ def sphere(diameter,center=point(0,0,0),depth=2):
 
         
 if __name__ == "__main__":
-    from yapcad.pyglet_drawable import *
+    import sys
+    try:
+        from yapcad.pyglet_drawable import *
+        dd=pygletDraw()
+    except RuntimeError as err:
+        print("\nSkipping OpenGL rendering: {}".format(err))
+        sys.exit(0)
+    except Exception as err:
+        print("\nSkipping OpenGL rendering due to unexpected error: {}".format(err))
+        sys.exit(1)
     print("example9.py -- yapCAD 3D geometry demonstration")
     print("""
 This is a demonstration of the creation and rendering of
@@ -127,7 +136,6 @@ engine.
 In this example we create an icosohedron centered at the orign and
 tesellate it spherically""")
 
-    dd=pygletDraw()
     dd.linecolor = 'white'
 
     verts,normals,faces = sphere(50.0,point(0,0,0),3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,20 @@ authors = [
 ]
 description = "yet another procedural CAD and computational geometry system"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
-	      "ezdxf",
-	      "pyglet < 2",
-	      "mpmath"
-	      ]
+      "ezdxf>=1.1",
+      "pyglet>=1.5,<2",
+      "mpmath>=1.2",
+      "pyobjc-core; platform_system == 'Darwin'",
+      "pyobjc-framework-Cocoa; platform_system == 'Darwin'",
+      "pyobjc-framework-Quartz; platform_system == 'Darwin'"
+      ]
 
 [project.optional-dependencies]
 tests = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@
 # numpy==1.13.3
 # scipy==1.0
 #
-ezdxf
-pyglet<2
-mpmath
+ezdxf>=1.1
+pyglet>=1.5,<2
+mpmath>=1.2
+pyobjc-core; platform_system == "Darwin"
+pyobjc-framework-Cocoa; platform_system == "Darwin"
+pyobjc-framework-Quartz; platform_system == "Darwin"

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,17 @@ package_dir =
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = ezdxf; pyglet<2; mpmath
+install_requires =
+    ezdxf>=1.1
+    pyglet>=1.5,<2
+    mpmath>=1.2
+    pyobjc-core; platform_system == "Darwin"
+    pyobjc-framework-Cocoa; platform_system == "Darwin"
+    pyobjc-framework-Quartz; platform_system == "Darwin"
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-# python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+python_requires = >=3.10
 
 [options.packages.find]
 where = src
@@ -96,5 +102,3 @@ version = 3.2.3
 package = yapcad
 extensions =
     no_skeleton
-
-

--- a/src/yapcad/__init__.py
+++ b/src/yapcad/__init__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-from pkg_resources import get_distribution, DistributionNotFound
+try:  # Python >= 3.8
+    from importlib.metadata import PackageNotFoundError, version
+except ModuleNotFoundError:  # pragma: no cover - for Python < 3.8
+    from importlib_metadata import PackageNotFoundError, version
+
 
 try:
-    # Change here if project is renamed and does not equal the package name
-    dist_name = 'yapCAD'
-    __version__ = get_distribution(dist_name).version
-except DistributionNotFound:
-    __version__ = 'unknown'
-finally:
-    del get_distribution, DistributionNotFound
+    __version__ = version("yapCAD")
+except PackageNotFoundError:  # pragma: no cover - handled when package not installed
+    __version__ = "unknown"

--- a/src/yapcad/combine.py
+++ b/src/yapcad/combine.py
@@ -10,16 +10,22 @@ class Boolean(IntersectGeometry):
 
     types = ('union','intersection','difference')
     
-    def __init__(self,type='union',polys=[]):
+    def __init__(self, type='union', polys=None):
+        super().__init__()
+        if type not in self.types:
+            raise ValueError('invalid type passed to Boolean(): {}'.format(type))
+
+        if polys is None:
+            polys = []
+
         for p in polys:
-            if not ( isinstance(p,Polygon) or isinstance(p,Boolean) ):
+            if not (isinstance(p, Polygon) or isinstance(p, Boolean)):
                 raise ValueError('non-poly or non-boolean passed to Boolean(): {}'.format(p))
-            if not type in self.types:
-                raise ValueError('invalid type passed to Boolean(): {}'.format(tpe))
-            self._elem=list(polys)
-            self._type=type
-            self._update=True
-            self._outline=[]
+
+        self._elem = list(polys)
+        self._type = type
+        self._update = True
+        self._outline = []
 
 
     def combine_geom(self,g1,g2):

--- a/src/yapcad/geometry.py
+++ b/src/yapcad/geometry.py
@@ -18,7 +18,7 @@
 ## classically-definalble gap (or the possibility thereof) then
 ## implement Geometry instead
 
-import copy
+from copy import deepcopy
 from yapcad.geom import *
 
 
@@ -43,7 +43,7 @@ class Geometry:
         return
 
     def geom(self):
-        if self.update:
+        if self._update:
             self._updateInternals()
         return deepcopy(self._elem)
 


### PR DESCRIPTION
Summary

  - Raise the supported runtime to Python 3.10+, pin pyglet back to the 1.x line, and keep ezdxf/mpmath/PyObjC aligned in
  pyproject.toml, setup.cfg, and requirements.txt.
  - Wrap every OpenGL example (example1, example8-gl, example9, example10, example11, example12, and boxcut) in defensive  guards: if pyglet can’t initialize Cocoa, they now emit a friendly “Skipping” message and either fall back to DXF or
  exit cleanly.

  Testing

  - PYTHONPATH=./src python3.12 -m pytest --override-ini addopts= (pass)