### PR TITLE
docs: enable myst_parser so Markdown docs actually publish

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,14 +79,28 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo',
               'sphinx.ext.doctest', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
               'sphinx.ext.napoleon']
 
+# Enable MyST so the Markdown docs in the toctree (DSL Guide/Tutorial/Reference,
+# schema specs, etc.) are parsed and published. Without this they emit
+# "nonexisting document" warnings and do not render on the site.
+try:
+    import myst_parser  # noqa: F401
+    extensions.append('myst_parser')
+except ImportError:
+    # MyST not installed in this build environment; .rst docs still build.
+    pass
+
 if _has_rtd_theme:
     extensions.append('sphinx_rtd_theme')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-# The suffix of source filenames.
-source_suffix = '.rst'
+# The suffix of source filenames. Markdown is handled by myst_parser when
+# available (see extensions above).
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 # Sphinx documentation requirements
 sphinx>=6
 sphinx_rtd_theme
+myst-parser  # parse the Markdown docs referenced from the toctree (DSL guide/tutorial/reference, schema specs)
 
 # Note: yapCAD package is installed via .readthedocs.yml (method: pip, path: .)
 # to enable autodoc/apidoc generation of submodule API documentation


### PR DESCRIPTION
The docs toctree (index.rst) references several Markdown documents — dsl_tutorial, dsl_reference, material_schema_spec, mesh_validation, etc. — but conf.py only registered source_suffix='.rst' and never loaded a Markdown parser. As a result Sphinx emitted 'toctree contains reference to nonexisting document' for every .md file and those pages did NOT render on the published (Read the Docs) site.

Verified by A/B build:
- WITHOUT this change: dsl_guide/dsl_tutorial/dsl_reference all fail with 'nonexisting document'; no HTML produced.
- WITH this change: all three render to HTML; build succeeds.

Fix (minimal, standard):
- conf.py: append 'myst_parser' to extensions (guarded by a try/import so an RST-only build still works if MyST isn't installed) and set source_suffix to map .rst→restructuredtext, .md→markdown.
- docs/requirements.txt: add myst-parser so Read the Docs installs it.

This is a pure infrastructure fix — no doc content changes here (the new DSL Language Guide + toctree wiring land in a separate commit).

Co-authored-by: jarvis-rich